### PR TITLE
Horizontal scroll on mobile for technology filters

### DIFF
--- a/resources/views/components/orgs-list.blade.php
+++ b/resources/views/components/orgs-list.blade.php
@@ -1,9 +1,12 @@
 <div>
     <div class="mb-2 md:mb-10">
         <div
-            x-data="{filterTechnology: @js($filterTechnology)}"
-            x-init="filterTechnology !== null && document.getElementById(filterTechnology).scrollIntoView(false)"
-            class="flex pb-1 overflow-x-scroll sm:pb-0 sm:flex-wrap sm:justify-center sm:overflow-x-hidden font-mono text-sm font-bold uppercase md:text-base  scrollbar:!w-1.5 scrollbar:!h-1.5 scrollbar:bg-transparent scrollbar-track:!bg-bgrey-100/50 scrollbar-thumb:!rounded scrollbar-thumb:!bg-bgrey-200 scrollbar-track:!rounded"
+            x-data="{ filterTechnology: @js($filterTechnology) }"
+            x-init="
+                filterTechnology !== null &&
+                    document.getElementById(filterTechnology).scrollIntoView(false)
+            "
+            class="flex overflow-x-scroll pb-1 font-mono text-sm font-bold uppercase scrollbar:!h-1.5 scrollbar:!w-1.5 scrollbar:bg-transparent scrollbar-track:!rounded scrollbar-track:!bg-bgrey-100/50 scrollbar-thumb:!rounded scrollbar-thumb:!bg-bgrey-200 sm:flex-wrap sm:justify-center sm:overflow-x-hidden sm:pb-0 md:text-base"
         >
             <a
                 href="/"

--- a/resources/views/components/orgs-list.blade.php
+++ b/resources/views/components/orgs-list.blade.php
@@ -1,6 +1,10 @@
 <div>
     <div class="mb-2 md:mb-10">
-        <div class="flex pb-1 overflow-x-scroll sm:pb-0 sm:flex-wrap sm:justify-center sm:overflow-x-hidden font-mono text-sm font-bold uppercase md:text-base">
+        <div
+            x-data="{filterTechnology: @js($filterTechnology)}"
+            x-init="filterTechnology !== null && document.getElementById(filterTechnology).scrollIntoView(false)"
+            class="flex pb-1 overflow-x-scroll sm:pb-0 sm:flex-wrap sm:justify-center sm:overflow-x-hidden font-mono text-sm font-bold uppercase md:text-base"
+        >
             <a
                 href="/"
                 class="{{ $filterTechnology == null ? 'border-tighten-yellow text-black hover:border-tighten-yellow' : 'text-gray-400 hover:text-gray-600 hover:border-gray-400 ' }} border-b-2 border-black/10 px-3 py-1 transition duration-300 active:border-tighten-yellow active:text-tighten-yellow"

--- a/resources/views/components/orgs-list.blade.php
+++ b/resources/views/components/orgs-list.blade.php
@@ -3,7 +3,7 @@
         <div
             x-data="{filterTechnology: @js($filterTechnology)}"
             x-init="filterTechnology !== null && document.getElementById(filterTechnology).scrollIntoView(false)"
-            class="flex pb-1 overflow-x-scroll sm:pb-0 sm:flex-wrap sm:justify-center sm:overflow-x-hidden font-mono text-sm font-bold uppercase md:text-base"
+            class="flex pb-1 overflow-x-scroll sm:pb-0 sm:flex-wrap sm:justify-center sm:overflow-x-hidden font-mono text-sm font-bold uppercase md:text-base  scrollbar:!w-1.5 scrollbar:!h-1.5 scrollbar:bg-transparent scrollbar-track:!bg-bgrey-100/50 scrollbar-thumb:!rounded scrollbar-thumb:!bg-bgrey-200 scrollbar-track:!rounded"
         >
             <a
                 href="/"

--- a/resources/views/components/orgs-list.blade.php
+++ b/resources/views/components/orgs-list.blade.php
@@ -1,6 +1,6 @@
 <div>
     <div class="mb-2 md:mb-10">
-        <div class="flex flex-wrap justify-center font-mono text-sm font-bold uppercase md:text-base">
+        <div class="flex pb-1 overflow-x-scroll sm:pb-0 sm:flex-wrap sm:justify-center sm:overflow-x-hidden font-mono text-sm font-bold uppercase md:text-base">
             <a
                 href="/"
                 class="{{ $filterTechnology == null ? 'border-tighten-yellow text-black hover:border-tighten-yellow' : 'text-gray-400 hover:text-gray-600 hover:border-gray-400 ' }} border-b-2 border-black/10 px-3 py-1 transition duration-300 active:border-tighten-yellow active:text-tighten-yellow"
@@ -12,6 +12,7 @@
                 <a
                     href="{{ route('technologies.show', $tech->slug) }}"
                     class="{{ $filterTechnology == $tech->slug ? 'border-tighten-yellow hover:border-tighten-yellow text-black ' : 'text-bgrey-400 hover:text-gray-600 hover:border-gray-400 ' }} border-b-2 border-black/10 px-3 py-1 transition duration-300 active:border-tighten-yellow active:text-tighten-yellow"
+                    id="{{ $tech->slug }}"
                 >
                     {{ $tech->name }}
                 </a>

--- a/resources/views/organizations/index.blade.php
+++ b/resources/views/organizations/index.blade.php
@@ -1,5 +1,9 @@
 <x-public-layout>
-    <x-orgs-list :organizations="$organizations" :technologies="$technologies" :filterTechnology="$filterTechnology"></x-orgs-list>
+    <x-orgs-list
+        :organizations="$organizations"
+        :technologies="$technologies"
+        :filterTechnology="$filterTechnology"
+    ></x-orgs-list>
 
     <div class="mt-24 text-center text-bgrey-500 md:text-2xl" id="about">
         <h2 class="mb-6 text-2xl font-bold uppercase text-black md:text-4xl">About</h2>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -48,5 +48,14 @@ export default {
         },
     },
 
-    plugins: [forms],
+    plugins: [
+        forms,
+        // used to style landing page's horizontal scrollbar on mobile
+        function ({ addVariant }) {
+            addVariant('supports-scrollbars', '@supports selector(::-webkit-scrollbar)')
+            addVariant('scrollbar', '&::-webkit-scrollbar')
+            addVariant('scrollbar-track', '&::-webkit-scrollbar-track')
+            addVariant('scrollbar-thumb', '&::-webkit-scrollbar-thumb')
+        },
+    ],
 };


### PR DESCRIPTION
This PR adds a horizontal scrolling section for the technology filters on mobile. The rest of the styling has remained the same. I also added some "nice-to-have" features:

- Scroll to the selected filter when it's not visible 
  - I wanted to use `x-ref` instead of `getElementById` however [Alpine.js v3 does not allow dynamic](https://alpinejs.dev/upgrade-guide#x-ref-no-more-dynamic) `$refs`
- A styled scrollbar so there isn't a chunky one on non-Mac machines

Default Screen:
 
<img width="365" alt="Screenshot 2024-07-12 at 6 10 55 PM" src="https://github.com/user-attachments/assets/800d95be-e4f1-475b-87ca-ba2e6c4c22b7">

Small Screen:

<img width="656" alt="Screenshot 2024-07-12 at 6 11 05 PM" src="https://github.com/user-attachments/assets/6acebcd0-4943-4bb7-8cdb-5c789b979490">

Medium Screen:

<img width="760" alt="Screenshot 2024-07-12 at 6 11 13 PM" src="https://github.com/user-attachments/assets/39b63564-dd17-4bb6-93ff-735632ceff62">

Large Screen:

<img width="1102" alt="Screenshot 2024-07-12 at 6 11 23 PM" src="https://github.com/user-attachments/assets/c3a29016-8292-40e8-98e9-0ee08733cdfe">

