### PR TITLE
Make images on header high priority (for mobile)

### DIFF
--- a/resources/views/layouts/public.blade.php
+++ b/resources/views/layouts/public.blade.php
@@ -56,7 +56,7 @@
                         class="mx-auto mb-5 mt-16 flex w-72 justify-center text-5xl font-bold hover:text-black/70 md:w-auto lg:col-start-2"
                     >
                         <h1>
-                            <img src="/images/bwl-logo.svg" loading="lazy" alt="Built With Laravel" class="w-144" />
+                            <img src="/images/bwl-logo.svg" fetchpriority="high" alt="Built With Laravel" class="w-144" />
                         </h1>
                     </a>
 
@@ -67,7 +67,7 @@
                         <span class="mr-2 mt-1">Curated by</span>
                         <img
                             src="/images/tighten-logo.svg"
-                            loading="lazy"
+                            fetchpriority="high"
                             alt="Tighten"
                             width="100"
                             height="22"


### PR DESCRIPTION
## Highlights
On mobile there this funky flicker thats specially noticeable when switching tabs. By making them high priority will make the flicker disappear.

Issue - https://builtwithlaravel.com/

https://github.com/user-attachments/assets/55795b61-23ca-473d-8e26-605ec7e6b978



Fix  - https://built-with-laravel.nucliuz.com/

https://github.com/user-attachments/assets/e9f89243-27c4-4d53-bd4a-0d0f82de579c

