### PR TITLE
Implements page caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /public/build
 /public/hot
 /public/storage
+/public/page-cache
 /storage/*.key
 /storage/debugbar
 /vendor

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,12 +6,15 @@ use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__ . '/../routes/web.php',
-        commands: __DIR__ . '/../routes/console.php',
+        web: __DIR__.'/../routes/web.php',
+        commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        return $middleware
+            ->alias([
+                'page-cache' => Silber\PageCache\Middleware\CacheResponse::class,
+            ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "laravel/tinker": "^2.9",
         "livewire/livewire": "^3.4",
         "livewire/volt": "^1.0",
+        "silber/page-cache": "^1.1",
         "tightenco/duster": "^3.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7270100446405c9af82336c45714a894",
+    "content-hash": "a5450877fa6731d779b33004466c6433",
     "packages": [
         {
             "name": "brick/math",
@@ -3726,6 +3726,71 @@
                 }
             ],
             "time": "2024-04-27T21:32:50+00:00"
+        },
+        {
+            "name": "silber/page-cache",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JosephSilber/page-cache.git",
+                "reference": "6c37f01ef63cbd518b370c2ccaeccd0052c14bb4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JosephSilber/page-cache/zipball/6c37f01ef63cbd518b370c2ccaeccd0052c14bb4",
+                "reference": "6c37f01ef63cbd518b370c2ccaeccd0052c14bb4",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^11.0",
+                "illuminate/filesystem": "^11.0",
+                "php": "^8.2",
+                "symfony/http-foundation": "^7.0"
+            },
+            "require-dev": {
+                "illuminate/container": "^11.0",
+                "laravel/pint": "^1.14",
+                "mockery/mockery": "^1.6.9",
+                "pestphp/pest": "3.x-dev",
+                "phpunit/phpunit": "^11.0",
+                "symfony/var-dumper": "^7.0"
+            },
+            "suggest": {
+                "illuminate/console": "Allows clearing the cache via artisan"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Silber\\PageCache\\LaravelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Silber\\PageCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joseph Silber",
+                    "email": "contact@josephsilber.com"
+                }
+            ],
+            "description": "Caches responses as static files on disk for lightning fast page loads.",
+            "keywords": [
+                "cache",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/JosephSilber/page-cache/issues",
+                "source": "https://github.com/JosephSilber/page-cache/tree/v1.1.0"
+            },
+            "time": "2024-03-19T03:39:06+00:00"
         },
         {
             "name": "symfony/clock",

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,38 @@
 <?php
 
+use App\Models\Organization;
+use App\Models\Technology;
 use Illuminate\Foundation\Inspiring;
+use Illuminate\Http\Client\Pool;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote')->hourly();
+
+Artisan::command('page-cache:warmup', function () {
+    $this->call('page-cache:clear');
+
+    $this->components->info('Making requests to warm up page caches...');
+
+    Http::pool(function (Pool $pool) {
+        $requests = [
+            $pool->get(route('home')),
+        ];
+
+        // Organization pages...
+        Organization::query()->oldest()->eachById(function (Organization $organization) use ($requests, $pool) {
+            $requests[] = $pool->get(route('organizations.show', $organization));
+        });
+
+        // Technology pages...
+        Technology::query()->oldest()->eachById(function (Technology $technology) use ($requests, $pool) {
+            $requests[] = $pool->get(route('home', ['technology' => $technology]));
+        });
+
+        return $requests;
+    });
+
+    $this->components->info('Done!');
+})->purpose('Makes requests to the website so we can warmup page cache.');

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,12 +4,12 @@ use App\Http\Controllers\OrganizationController;
 use App\Http\Controllers\SuggestionsController;
 use Illuminate\Support\Facades\Route;
 
-Route::resource('organizations', OrganizationController::class)->only('show');
+Route::resource('organizations', OrganizationController::class)->only('show')->middleware('page-cache');
 Route::resource('suggestions', SuggestionsController::class)->only(['create', 'store']);
 
-require __DIR__ . '/auth.php';
+require __DIR__.'/auth.php';
 
-Route::get('{technology:slug?}', [OrganizationController::class, 'index'])->name('home');
+Route::get('{technology:slug?}', [OrganizationController::class, 'index'])->name('home')->middleware('page-cache');
 
 /*
 


### PR DESCRIPTION
### Added

- Adds the [PageCache](https://github.com/JosephSilber/page-cache) Composer package
- Adds a `page-cache:warmup` command that automatically purges caches and triggers new requests so the cache is rebuilt. The idea is this command should be added to the deploy script at the very end

---

#### Instructions

After merge, we need to:

1. Add the warmup command at the very last step of the deploy script:

    ```bash
    php artisan page-cache:warmup
    ```

1. Update the Nginx config to try the page-cache folder in the public directory first before forwarding the request to PHP-FPM ([docs](https://github.com/JosephSilber/page-cache?tab=readme-ov-file#url-rewriting)):

    ```diff
    location / {
    -   try_files $uri $uri/ /index.php?$query_string;
    +   try_files $uri $uri/ /page-cache/$uri.html /page-cache/$uri.json /page-cache/$uri.xml /index.php?$query_string;
    }
    ```

---

closes #10 