### PR TITLE
Suggestions technology as checkboxes

### DIFF
--- a/resources/views/suggestions/create.blade.php
+++ b/resources/views/suggestions/create.blade.php
@@ -97,7 +97,7 @@
 
                         <div class="flex flex-wrap gap-2 leading-none">
                             @foreach ($technologies as $technology)
-                                <label class="text-center rounded-xl border-none px-2 pt-1.5 pb-1 leading-none text-gray-500 font-semibold uppercase text-xs font-mono bg-black/4 backdrop-blur-lg transition cursor-pointer has-[:checked]:bg-black has-[:checked]:text-white">
+                                <label class="align-middle text-center rounded-xl border-none px-2 py-1 leading-none text-gray-500 font-medium uppercase text-sm font-sans bg-black/4 backdrop-blur-lg transition cursor-pointer has-[:checked]:bg-black has-[:checked]:text-white">
                                     <input class="sr-only" type="checkbox" name="technologies[]" value="{{ $technology->id }}" @if (in_array($technology->id, old('technologies', []))) checked @endif />
                                     <span class="whitespace-nowrap">{{ $technology->name }}</span>
                                 </label>

--- a/resources/views/suggestions/create.blade.php
+++ b/resources/views/suggestions/create.blade.php
@@ -13,7 +13,7 @@
                 <form method="post" action="{{ route('suggestions.store') }}">
                     @csrf
                     <div>
-                        <label id="organization-heading" class="mb-1 block">Tell us about the Organization</label>
+                        <label id="organization-heading" for="name" class="mb-1 block">Tell us about the Organization</label>
 
                         <div class="mb-2 relative group">
                             <label for="name" class="
@@ -59,7 +59,7 @@
                     </div>
 
                     <div class="mb-6 gap-x-10 md:grid md:grid-cols-2">
-                        <span id="sources-heading" class="col-span-2">How do you know they use Laravel?</span>
+                        <label id="sources-heading" for="public_source" class="col-span-2">How do you know they use Laravel?</label>
 
                         <div class="mb-4 md:mb-0 relative group">
                             <label for="public_source" id="sources-label-public" class="
@@ -156,7 +156,7 @@
                     </div>
 
                     <div>
-                        <label id="suggester-heading" class="mb-1 block">Tell us about yourself</label>
+                        <label id="suggester-heading" for="suggester_name" class="mb-1 block">Tell us about yourself</label>
 
                         <div class="mb-1 relative group">
                             <label for="suggester_name" class="

--- a/resources/views/suggestions/create.blade.php
+++ b/resources/views/suggestions/create.blade.php
@@ -84,32 +84,28 @@
                             </span>
                         </div>
 
-                        <div>
-                            <div class="relative group">
-                                <label for="private_source" id="sources-label-private" class="
-                                    z-10 block absolute top-0 -translate-y-1 ml-2 px-1 py-0 backdrop-blur-lg bg-black/4 rounded-lg text-xs font-normal leading-normal duration-300 ease-out cursor-text
-                                    text-black
-                                    group-has-[:placeholder-shown]:z-0 group-has-[:placeholder-shown]:text-transparent group-has-[:placeholder-shown]:top-[17px] group-has-[:placeholder-shown]:ml-3 group-has-[:placeholder-shown]:text-[16px] group-has-[:placeholder-shown]:bg-transparent group-has-[:placeholder-shown]:backdrop-blur-none
-                                    group-focus-within:!z-10 group-focus-within:!bg-black/4 group-focus-within:!text-black group-focus-within:!top-0 group-focus-within:!ml-2 group-focus-within:!text-xs group-focus-within:!backdrop-blur-lg
-                                ">Private</label>
+                        <div class="relative group">
+                            <label for="private_source" id="sources-label-private" class="
+                                z-10 block absolute top-0 -translate-y-1 ml-2 px-1 py-0 backdrop-blur-lg bg-black/4 rounded-lg text-xs font-normal leading-normal duration-300 ease-out cursor-text
+                                text-black
+                                group-has-[:placeholder-shown]:z-0 group-has-[:placeholder-shown]:text-transparent group-has-[:placeholder-shown]:top-[17px] group-has-[:placeholder-shown]:ml-3 group-has-[:placeholder-shown]:text-[16px] group-has-[:placeholder-shown]:bg-transparent group-has-[:placeholder-shown]:backdrop-blur-none
+                                group-focus-within:!z-10 group-focus-within:!bg-black/4 group-focus-within:!text-black group-focus-within:!top-0 group-focus-within:!ml-2 group-focus-within:!text-xs group-focus-within:!backdrop-blur-lg
+                            ">Private</label>
 
-                                <img aria-hidden="true" src="/images/lock.svg" alt="Lock" class="absolute right-3 top-3 z-50" />
+                            <img aria-hidden="true" src="/images/lock.svg" alt="Lock" class="absolute right-3 top-3 z-50" />
 
-                                <textarea
-                                    class="h-32 w-128 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg my-2 border-gray-300 ring-offset-background placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-zinc-800"
-                                    placeholder="Private"
-                                    name="private_source"
-                                    id="private_source"
-                                    aria-labelledby="sources-heading sources-help-private"
-                                >{{ old('private_source') }}</textarea>
-                            </div>
+                            <textarea
+                                class="h-32 w-128 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg mt-2 border-gray-300 ring-offset-background placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-zinc-800"
+                                placeholder="Private"
+                                name="private_source"
+                                id="private_source"
+                                aria-labelledby="sources-heading sources-help-private"
+                            >{{ old('private_source') }}</textarea>
 
-                            <span class="block">
-                                <span id="sources-help-private" class="text-sm italic text-gray-500">
-                                    (if this information
-                                    <strong>cannot</strong>
-                                    safely be shared publicly)
-                                </span>
+                            <span id="sources-help-private" class="block text-sm italic text-gray-500">
+                                (if this information
+                                <strong>cannot</strong>
+                                safely be shared publicly)
                             </span>
                         </div>
                     </div>

--- a/resources/views/suggestions/create.blade.php
+++ b/resources/views/suggestions/create.blade.php
@@ -2,7 +2,7 @@
     <div class="mx-auto max-w-8xl">
         <div class="gap-10 lg:grid lg:grid-cols-3">
             <div class="col-span-2 text-lg">
-                <h2 class="mb-10 text-3xl">Suggest an organization</h2>
+                <h2 class="mb-8 text-3xl">Suggest an organization</h2>
 
                 @if (Session::has('flash'))
                     <div class="mb-4 max-w-5xl border border-blue-400 bg-blue-100 px-4 py-2 text-blue-900">
@@ -12,128 +12,201 @@
 
                 <form method="post" action="{{ route('suggestions.store') }}">
                     @csrf
-                    <div class="mb-8">
-                        <label class="mb-1 block">Organization name *</label>
-                        <input
-                            type="text"
-                            class="w-96 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg"
-                            name="name"
-                            placeholder="Tighten"
-                            value="{{ old('name') }}"
-                            required
-                        />
-                        <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                    <div>
+                        <label id="organization-heading" class="mb-1 block">Tell us about the Organization</label>
+
+                        <div class="mb-2 relative group">
+                            <label for="name" class="
+                                z-10 block absolute top-0 -translate-y-1 ml-2 px-1 py-0 backdrop-blur-lg bg-black/4 rounded-lg text-xs font-normal leading-normal duration-300 ease-out cursor-text
+                                text-black
+                                group-has-[:placeholder-shown]:z-0 group-has-[:placeholder-shown]:text-transparent group-has-[:placeholder-shown]:top-[17px] group-has-[:placeholder-shown]:ml-3 group-has-[:placeholder-shown]:text-[16px] group-has-[:placeholder-shown]:bg-transparent group-has-[:placeholder-shown]:backdrop-blur-none
+                                group-focus-within:!z-10 group-focus-within:!bg-black/4 group-focus-within:!text-black group-focus-within:!top-0 group-focus-within:!ml-2 group-focus-within:!text-xs group-focus-within:!backdrop-blur-lg
+                            ">Organization name *</label>
+
+                            <input
+                                type="text"
+                                class="w-96 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg my-1 border-gray-300 ring-offset-background placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-zinc-800"
+                                name="name"
+                                placeholder="Organization name *"
+                                id="name"
+                                aria-labelledby="organization-heading name"
+                                value="{{ old('name') }}"
+                                required
+                            />
+
+                            <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                        </div>
+
+                        <div class="mb-2 relative group">
+                            <label for="url" class="
+                                z-10 block absolute top-0 -translate-y-1 ml-2 px-1 py-0 backdrop-blur-lg bg-black/4 rounded-lg text-xs font-normal leading-normal duration-300 ease-out cursor-text
+                                text-black
+                                group-has-[:placeholder-shown]:z-0 group-has-[:placeholder-shown]:text-transparent group-has-[:placeholder-shown]:top-[17px] group-has-[:placeholder-shown]:ml-3 group-has-[:placeholder-shown]:text-[16px] group-has-[:placeholder-shown]:bg-transparent group-has-[:placeholder-shown]:backdrop-blur-none
+                                group-focus-within:!z-10 group-focus-within:!bg-black/4 group-focus-within:!text-black group-focus-within:!top-0 group-focus-within:!ml-2 group-focus-within:!text-xs group-focus-within:!backdrop-blur-lg
+                            ">Organization URL *</label>
+
+                            <input
+                                type="url"
+                                class="w-96 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg my-1 border-gray-300 ring-offset-background placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-zinc-800"
+                                name="url"
+                                id="url"
+                                placeholder="https://tighten.com/"
+                                value="{{ old('url') }}"
+                                required
+                            />
+                            <x-input-error :messages="$errors->get('url')" class="mt-2" />
+                        </div>
                     </div>
 
-                    <div class="mb-8">
-                        <label class="mb-1 block">Organization URL *</label>
-                        <input
-                            type="url"
-                            class="w-96 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg"
-                            name="url"
-                            placeholder="https://tighten.com/"
-                            value="{{ old('url') }}"
-                            required
-                        />
-                        <x-input-error :messages="$errors->get('url')" class="mt-2" />
-                    </div>
+                    <div class="mb-6 gap-x-10 md:grid md:grid-cols-2">
+                        <span id="sources-heading" class="col-span-2">How do you know they use Laravel?</span>
 
-                    <div class="mb-8 gap-x-10 md:grid md:grid-cols-2">
-                        <div class="col-span-2">How do you know they use Laravel?</div>
+                        <div class="mb-4 md:mb-0 relative group">
+                            <label for="public_source" id="sources-label-public" class="
+                                z-10 block absolute top-0 -translate-y-1 ml-2 px-1 py-0 backdrop-blur-lg bg-black/4 rounded-lg text-xs font-normal leading-normal duration-300 ease-out cursor-text
+                                text-black
+                                group-has-[:placeholder-shown]:z-0 group-has-[:placeholder-shown]:text-transparent group-has-[:placeholder-shown]:top-[17px] group-has-[:placeholder-shown]:ml-3 group-has-[:placeholder-shown]:text-[16px] group-has-[:placeholder-shown]:bg-transparent group-has-[:placeholder-shown]:backdrop-blur-none
+                                group-focus-within:!z-10 group-focus-within:!bg-black/4 group-focus-within:!text-black group-focus-within:!top-0 group-focus-within:!ml-2 group-focus-within:!text-xs group-focus-within:!backdrop-blur-lg
+                            ">Public</label>
 
-                        <div class="mb-6 md:mb-0">
                             <textarea
-                                class="h-32 w-128 max-w-full rounded-xl border-none bg-black/4 text-lg backdrop-blur-lg"
+                                class="h-32 w-128 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg mt-2 border-gray-300 ring-offset-background placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-zinc-800"
                                 placeholder="Public"
                                 name="public_source"
-                            >
-{{ old('public_source') }}</textarea
-                            >
-                            <label class="-mt-2 block">
-                                <span class="text-sm italic text-gray-500">
-                                    (if this information
-                                    <strong>can</strong>
-                                    safely be shared publicly)
-                                </span>
-                            </label>
+                                id="public_source"
+                                aria-labelledby="sources-heading sources-help-public"
+                            >{{ old('public_source') }}</textarea>
+
+                            <span id="sources-help-public" class="block text-sm italic text-gray-500">
+                                (if this information
+                                <strong>can</strong>
+                                safely be shared publicly)
+                            </span>
                         </div>
 
                         <div>
-                            <div class="relative">
-                                <img src="/images/lock.svg" alt="Lock" class="absolute right-3 top-3 z-50" />
+                            <div class="relative group">
+                                <label for="private_source" id="sources-label-private" class="
+                                    z-10 block absolute top-0 -translate-y-1 ml-2 px-1 py-0 backdrop-blur-lg bg-black/4 rounded-lg text-xs font-normal leading-normal duration-300 ease-out cursor-text
+                                    text-black
+                                    group-has-[:placeholder-shown]:z-0 group-has-[:placeholder-shown]:text-transparent group-has-[:placeholder-shown]:top-[17px] group-has-[:placeholder-shown]:ml-3 group-has-[:placeholder-shown]:text-[16px] group-has-[:placeholder-shown]:bg-transparent group-has-[:placeholder-shown]:backdrop-blur-none
+                                    group-focus-within:!z-10 group-focus-within:!bg-black/4 group-focus-within:!text-black group-focus-within:!top-0 group-focus-within:!ml-2 group-focus-within:!text-xs group-focus-within:!backdrop-blur-lg
+                                ">Private</label>
+
+                                <img aria-hidden="true" src="/images/lock.svg" alt="Lock" class="absolute right-3 top-3 z-50" />
+
                                 <textarea
-                                    class="h-32 w-128 max-w-full rounded-xl border-none bg-black/4 text-lg backdrop-blur-lg"
+                                    class="h-32 w-128 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg my-2 border-gray-300 ring-offset-background placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-zinc-800"
                                     placeholder="Private"
                                     name="private_source"
-                                >
-{{ old('private_source') }}</textarea
-                                >
+                                    id="private_source"
+                                    aria-labelledby="sources-heading sources-help-private"
+                                >{{ old('private_source') }}</textarea>
                             </div>
-                            <label class="-mt-2 block">
-                                <span class="text-sm italic text-gray-500">
+
+                            <span class="block">
+                                <span id="sources-help-private" class="text-sm italic text-gray-500">
                                     (if this information
                                     <strong>cannot</strong>
                                     safely be shared publicly)
                                 </span>
-                            </label>
+                            </span>
                         </div>
                     </div>
 
-                    <div class="mb-8">
-                        <label class="mb-1 block">
+                    <div class="mb-4">
+                        <label for="sites" class="mb-1 block">
                             What sites/microsites/apps specifically use Laravel? (new line for each URL)
                         </label>
-                        <textarea
-                            class="h-32 w-128 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg"
-                            name="sites"
-                            autocorrect="off"
-                            autocapitalize="none"
-                            placeholder="https://fieldgoal.io/"
-                        >{{ old('sites') }}</textarea>
+
+                        <div class="relative group">
+                            <label for="sites" class="
+                                z-10 block absolute top-0 -translate-y-1 ml-2 px-1 py-0 backdrop-blur-lg bg-black/4 rounded-lg text-xs font-normal leading-normal duration-300 ease-out cursor-text
+                                text-black
+                                group-has-[:placeholder-shown]:z-0 group-has-[:placeholder-shown]:text-transparent group-has-[:placeholder-shown]:top-[17px] group-has-[:placeholder-shown]:ml-3 group-has-[:placeholder-shown]:text-[16px] group-has-[:placeholder-shown]:bg-transparent group-has-[:placeholder-shown]:backdrop-blur-none
+                                group-focus-within:!z-10 group-focus-within:!bg-black/4 group-focus-within:!text-black group-focus-within:!top-0 group-focus-within:!ml-2 group-focus-within:!text-xs group-focus-within:!backdrop-blur-lg
+                            ">Sites</label>
+
+                            <textarea
+                                class="h-32 w-128 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg my-2 border-gray-300 ring-offset-background placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-zinc-800"
+                                id="sites"
+                                name="sites"
+                                autocorrect="off"
+                                autocapitalize="none"
+                                placeholder="https://fieldgoal.io/"
+                            >{{ old('sites') }}</textarea>
+                        </div>
                     </div>
 
-                    <div class="mb-8">
-                        <label class="mb-1 block">What technologies are they using?</label>
+                    <div class="mb-6">
+                        <label id="technologies-heading" class="mb-1 block">What technologies are they using?</label>
 
                         <div class="flex flex-wrap gap-2 leading-none">
                             @foreach ($technologies as $technology)
-                                <label class="align-middle text-center rounded-xl border-none px-2 py-1 leading-none text-gray-500 font-medium uppercase text-sm font-sans bg-black/4 backdrop-blur-lg transition cursor-pointer has-[:checked]:bg-black has-[:checked]:text-white">
-                                    <input class="sr-only" type="checkbox" name="technologies[]" value="{{ $technology->slug }}" @if (in_array($technology->slug, old('technologies', []))) checked @endif />
-                                    <span class="whitespace-nowrap">{{ $technology->name }}</span>
+                                <label class="align-middle text-center rounded-xl border-none px-2 py-1 leading-none text-gray-500 font-medium uppercase text-sm font-sans bg-black/4 backdrop-blur-lg transition cursor-pointer has-[:checked]:bg-black has-[:checked]:text-white ring-offset-background focus-within:outline-none focus-within:ring-1 focus-within:ring-zinc-800">
+                                    <input
+                                        class="sr-only"
+                                        type="checkbox"
+                                        name="technologies[]"
+                                        value="{{ $technology->slug }}"
+                                        aria-labelledby="{{ $loop->first ? "technologies-heading technology-{$technology->slug}" : "technology-{$technology->slug}" }}"
+                                        @if (in_array($technology->slug, old('technologies', []))) checked @endif
+                                    />
+
+                                    <span id="technology-{{ $technology->slug }}" class="whitespace-nowrap">{{ $technology->name }}</span>
                                 </label>
                             @endforeach
                         </div>
                     </div>
 
-                    <div class="mb-8">
-                        <label class="mb-1 block">Your name *</label>
-                        <input
-                            type="text"
-                            class="w-96 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg"
-                            name="suggester_name"
-                            placeholder="Firstname Lastname"
-                            value="{{ old('suggester_name') }}"
-                            required
-                        />
-                        <x-input-error :messages="$errors->get('suggester_name')" class="mt-2" />
-                    </div>
+                    <div>
+                        <label id="suggester-heading" class="mb-1 block">Tell us about yourself</label>
 
-                    <div class="mb-8">
-                        <label class="mb-1 block">Your email *</label>
-                        <input
-                            type="email"
-                            class="w-96 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg"
-                            name="suggester_email"
-                            placeholder="you@awesome.com"
-                            value="{{ old('suggester_email') }}"
-                            required
-                        />
-                        <x-input-error :messages="$errors->get('suggester_email')" class="mt-2" />
+                        <div class="mb-1 relative group">
+                            <label for="suggester_name" class="
+                                z-10 block absolute top-0 -translate-y-1 ml-2 px-1 py-0 backdrop-blur-lg bg-black/4 rounded-lg text-xs font-normal leading-normal duration-300 ease-out cursor-text
+                                text-black
+                                group-has-[:placeholder-shown]:z-0 group-has-[:placeholder-shown]:text-transparent group-has-[:placeholder-shown]:top-[17px] group-has-[:placeholder-shown]:ml-3 group-has-[:placeholder-shown]:text-[16px] group-has-[:placeholder-shown]:bg-transparent group-has-[:placeholder-shown]:backdrop-blur-none
+                                group-focus-within:!z-10 group-focus-within:!bg-black/4 group-focus-within:!text-black group-focus-within:!top-0 group-focus-within:!ml-2 group-focus-within:!text-xs group-focus-within:!backdrop-blur-lg
+                            ">Your name *</label>
+
+                            <input
+                                type="text"
+                                class="w-96 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg my-2 border-gray-300 ring-offset-background placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-zinc-800"
+                                name="suggester_name"
+                                id="suggester_name"
+                                aria-labelledby="suggester-heading suggester_name"
+                                placeholder="Firstname Lastname"
+                                value="{{ old('suggester_name') }}"
+                                required
+                            />
+                            <x-input-error :messages="$errors->get('suggester_name')" class="mt-2" />
+                        </div>
+
+                        <div class="mb-6 relative group">
+                            <label for="suggester_email" class="
+                                z-10 block absolute top-0 -translate-y-1 ml-2 px-1 py-0 backdrop-blur-lg bg-black/4 rounded-lg text-xs font-normal leading-normal duration-300 ease-out cursor-text
+                                text-black
+                                group-has-[:placeholder-shown]:z-0 group-has-[:placeholder-shown]:text-transparent group-has-[:placeholder-shown]:top-[17px] group-has-[:placeholder-shown]:ml-3 group-has-[:placeholder-shown]:text-[16px] group-has-[:placeholder-shown]:bg-transparent group-has-[:placeholder-shown]:backdrop-blur-none
+                                group-focus-within:!z-10 group-focus-within:!bg-black/4 group-focus-within:!text-black group-focus-within:!top-0 group-focus-within:!ml-2 group-focus-within:!text-xs group-focus-within:!backdrop-blur-lg
+                            ">Your email *</label>
+
+                            <input
+                                type="email"
+                                class="w-96 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg my-2 border-gray-300 ring-offset-background placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-zinc-800"
+                                name="suggester_email"
+                                id="suggester_email"
+                                placeholder="you@awesome.com"
+                                value="{{ old('suggester_email') }}"
+                                required
+                            />
+                            <x-input-error :messages="$errors->get('suggester_email')" class="mt-2" />
+                        </div>
                     </div>
 
                     <input
                         type="submit"
-                        class="float-right block rounded rounded-lg border-none bg-black p-2 px-5 text-sm text-white hover:bg-black/80"
+                        class="float-right block rounded-lg border-none bg-black p-2 px-5 text-sm text-white hover:bg-black/80"
                         value="Submit Suggestion"
                     />
                 </form>

--- a/resources/views/suggestions/create.blade.php
+++ b/resources/views/suggestions/create.blade.php
@@ -98,7 +98,7 @@
                         <div class="flex flex-wrap gap-2 leading-none">
                             @foreach ($technologies as $technology)
                                 <label class="align-middle text-center rounded-xl border-none px-2 py-1 leading-none text-gray-500 font-medium uppercase text-sm font-sans bg-black/4 backdrop-blur-lg transition cursor-pointer has-[:checked]:bg-black has-[:checked]:text-white">
-                                    <input class="sr-only" type="checkbox" name="technologies[]" value="{{ $technology->id }}" @if (in_array($technology->id, old('technologies', []))) checked @endif />
+                                    <input class="sr-only" type="checkbox" name="technologies[]" value="{{ $technology->slug }}" @if (in_array($technology->slug, old('technologies', []))) checked @endif />
                                     <span class="whitespace-nowrap">{{ $technology->name }}</span>
                                 </label>
                             @endforeach

--- a/resources/views/suggestions/create.blade.php
+++ b/resources/views/suggestions/create.blade.php
@@ -158,7 +158,7 @@
                     <div>
                         <label id="suggester-heading" for="suggester_name" class="mb-1 block">Tell us about yourself</label>
 
-                        <div class="mb-1 relative group">
+                        <div class="mb-2 relative group">
                             <label for="suggester_name" class="
                                 z-10 block absolute top-0 -translate-y-1 ml-2 px-1 py-0 backdrop-blur-lg bg-black/4 rounded-lg text-xs font-normal leading-normal duration-300 ease-out cursor-text
                                 text-black
@@ -168,7 +168,7 @@
 
                             <input
                                 type="text"
-                                class="w-96 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg my-2 border-gray-300 ring-offset-background placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-zinc-800"
+                                class="w-96 max-w-full rounded-xl border-none bg-black/4 backdrop-blur-lg mt-2 border-gray-300 ring-offset-background placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-zinc-800"
                                 name="suggester_name"
                                 id="suggester_name"
                                 aria-labelledby="suggester-heading suggester_name"

--- a/resources/views/suggestions/create.blade.php
+++ b/resources/views/suggestions/create.blade.php
@@ -89,27 +89,20 @@
                             autocorrect="off"
                             autocapitalize="none"
                             placeholder="https://fieldgoal.io/"
-                        >
-{{ old('sites') }}</textarea
-                        >
+                        >{{ old('sites') }}</textarea>
                     </div>
 
                     <div class="mb-8">
                         <label class="mb-1 block">What technologies are they using?</label>
-                        <select
-                            name="technologies[]"
-                            multiple
-                            class="w-64 rounded-xl border-none bg-black/4 backdrop-blur-lg md:h-32"
-                        >
+
+                        <div class="flex flex-wrap gap-2 leading-none">
                             @foreach ($technologies as $technology)
-                                <option
-                                    value="{{ $technology->slug }}"
-                                    {{ collect(old('technologies'))->contains($technology->slug) ? 'selected' : '' }}
-                                >
-                                    {{ $technology->name }}
-                                </option>
+                                <label class="text-center rounded-xl border-none px-2 pt-1.5 pb-1 leading-none text-gray-500 font-semibold uppercase text-xs font-mono bg-black/4 backdrop-blur-lg transition cursor-pointer has-[:checked]:bg-black has-[:checked]:text-white">
+                                    <input class="sr-only" type="checkbox" name="technologies[]" value="{{ $technology->id }}" @if (in_array($technology->id, old('technologies', []))) checked @endif />
+                                    <span class="whitespace-nowrap">{{ $technology->name }}</span>
+                                </label>
                             @endforeach
-                        </select>
+                        </div>
                     </div>
 
                     <div class="mb-8">


### PR DESCRIPTION
### Changelog

- **CHANGED**: Switch from a multi-select field to a checkbox styled as pills for the technologies selection. Also adds floating labels and some screen reader hints

---

<details>
<summary>Screenshots</summary>

desktop:
![image](https://github.com/user-attachments/assets/024e7bce-2f5d-41a5-900b-b984638c1fef)

mobile:
![image](https://github.com/user-attachments/assets/7b66ec01-defa-4638-adb0-2a5e6ad7d5a5)

floating labels:
![image](https://github.com/user-attachments/assets/de765f54-1c0a-49d5-a2c0-cf88e20652f3)

</details>

closes #8 
closes #12 