### PR TITLE
Passthrough clicking on visit website

### DIFF
--- a/resources/views/organizations/show.blade.php
+++ b/resources/views/organizations/show.blade.php
@@ -86,7 +86,7 @@
                         <div class="group relative">
                             <span
                                 target="_blank"
-                                class="w-38 absolute right-4 top-4 rounded-xl border bg-white px-4 shadow group-hover:bg-bgrey-100"
+                                class="w-38 pointer-events-none absolute right-4 top-4 rounded-xl border bg-white px-4 shadow group-hover:bg-bgrey-100"
                             >
                                 Visit website
                                 <img


### PR DESCRIPTION
## Highlights
When clicking on `Visit website` currently you end up being able to select the text, rather than being able to navigate to the site. By adding `pointer-events-none` to the badge, enables the click to passthrough. 

<details><summary>Screenshots</summary>
<p>

Issue
<img width="364" alt="image" src="https://github.com/user-attachments/assets/a3c6146f-7558-4ee2-a7fe-47ce20c2a23f">


</p>
</details> 