### PR TITLE
Update approve action to redirect and add to edit page

### DIFF
--- a/app/Filament/Resources/SuggestedOrganizationResource.php
+++ b/app/Filament/Resources/SuggestedOrganizationResource.php
@@ -94,6 +94,8 @@ class SuggestedOrganizationResource extends Resource
                     ->icon('heroicon-m-check-badge')
                     ->action(function (SuggestedOrganization $record) {
                         (new ApproveSuggestedOrganization)($record);
+
+                        return to_route('filament.bts.resources.organizations.edit', ['record' => str($record->name)->slug()]);
                     }),
                 Action::make('reject')
                     ->requiresConfirmation()

--- a/app/Filament/Resources/SuggestedOrganizationResource/Pages/EditSuggestedOrganization.php
+++ b/app/Filament/Resources/SuggestedOrganizationResource/Pages/EditSuggestedOrganization.php
@@ -2,7 +2,10 @@
 
 namespace App\Filament\Resources\SuggestedOrganizationResource\Pages;
 
+use App\Actions\ApproveSuggestedOrganization;
 use App\Filament\Resources\SuggestedOrganizationResource;
+use App\Models\SuggestedOrganization;
+use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 
@@ -13,6 +16,15 @@ class EditSuggestedOrganization extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('approve')
+                ->visible($this->record->approved_at === null)
+                ->requiresConfirmation()
+                ->icon('heroicon-m-check-badge')
+                ->action(function (SuggestedOrganization $record) {
+                    (new ApproveSuggestedOrganization)($record);
+
+                    return to_route('filament.bts.resources.organizations.edit', ['record' => str($record->name)->slug()]);
+                }),
             DeleteAction::make(),
         ];
     }

--- a/tests/Feature/Filament/SuggestedOrganizationTest.php
+++ b/tests/Feature/Filament/SuggestedOrganizationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Filament\Resources\SuggestedOrganizationResource\Pages\EditSuggestedOrganization;
+use App\Filament\Resources\SuggestedOrganizationResource\Pages\ListSuggestedOrganizations;
+use App\Models\SuggestedOrganization;
+use Livewire\Livewire;
+
+it('can approve suggestion from table', function () {
+    $suggested = SuggestedOrganization::factory()->create(['name' => 'Shiz University']);
+
+    Livewire::test(ListSuggestedOrganizations::class, ['record' => $suggested->id])
+        ->callTableAction('approve', $suggested->id)
+        ->assertRedirect(route('filament.bts.resources.organizations.edit', ['record' => 'shiz-university']));
+
+    expect($suggested->fresh()->approved_at)->not->toBeNull();
+});
+
+it('can approve suggestion from edit page', function () {
+    $suggested = SuggestedOrganization::factory()->create(['name' => 'Shiz']);
+
+    Livewire::test(EditSuggestedOrganization::class, ['record' => $suggested->id])
+        ->callAction('approve')
+        ->assertRedirect(route('filament.bts.resources.organizations.edit', ['record' => 'shiz']));
+
+    expect($suggested->fresh()->approved_at)->not->toBeNull();
+});
+
+it('can hide approval button if already approved', function () {
+    $suggested = SuggestedOrganization::factory()->create(['approved_at' => now()]);
+
+    Livewire::test(EditSuggestedOrganization::class, ['record' => $suggested->id])
+        ->assertActionHidden('approve');
+});


### PR DESCRIPTION
This PR:
- adds a redirect to the existing "Approve" action on the Suggested Organizations table
- adds the "Approve" action to the header section Edit Suggested Organization page
- adds tests for both


https://github.com/user-attachments/assets/640cbda3-6449-4047-987e-1e9c87a81f6e


https://github.com/user-attachments/assets/d7b24238-f6ac-4daf-88f3-75bd5f2a5bde

